### PR TITLE
Storage info: Fix FC when essential directories missing on SD

### DIFF
--- a/src/com/android/settings/deviceinfo/StorageVolumePreferenceCategory.java
+++ b/src/com/android/settings/deviceinfo/StorageVolumePreferenceCategory.java
@@ -310,7 +310,9 @@ public class StorageVolumePreferenceCategory extends PreferenceCategory {
     private static long totalValues(HashMap<String, Long> map, String... keys) {
         long total = 0;
         for (String key : keys) {
-            total += map.get(key);
+            if(map.containsKey(key)) {
+                total += map.get(key);
+            }
         }
         return total;
     }


### PR DESCRIPTION
We have to check if key exists in HashMap before trying
to get its value.
Reproduce: 
1) delete or rename "Movies" directory on external storage
2) launch Settings / Storage

Change-Id: If01603d867a0d20a1c294ee1b4e2897bd5e27264
