### PR TITLE
HALO: Option to pause the underlying app (2/2)

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -4538,6 +4538,8 @@
     <string name="halo_state_summary">For black/white-listing notifications pinging through HALO</string>
     <string name="halo_state_black">Black list</string>
     <string name="halo_state_white">White list</string>
+    <string name="halo_pause_title">HALO pause active app</string>
+    <string name="halo_pause_summary">When opening an app with HALO the underlying app will get paused (enabled by default on low memory devices)</string>
 
     <!-- Quick pulldown -->
     <string name="quick_pulldown_title">Quick pulldown</string>

--- a/res/xml/tool_bar_settings.xml
+++ b/res/xml/tool_bar_settings.xml
@@ -48,6 +48,11 @@
             android:defaultValue="true" />
 
         <CheckBoxPreference
+            android:key="halo_pause"
+            android:title="@string/halo_pause_title"
+            android:summary="@string/halo_pause_summary" />
+
+        <CheckBoxPreference
             android:key="show_clock"
             android:title="@string/show_clock_title" />
 

--- a/src/com/android/settings/paranoid/Toolbar.java
+++ b/src/com/android/settings/paranoid/Toolbar.java
@@ -16,6 +16,7 @@
 
 package com.android.settings.paranoid;
 
+import android.app.ActivityManager;
 import android.app.AlertDialog;
 import android.app.INotificationManager;
 import android.content.Context;
@@ -45,6 +46,7 @@ public class Toolbar extends SettingsPreferenceFragment
     private static final String KEY_HALO_STATE = "halo_state";
     private static final String KEY_HALO_HIDE = "halo_hide";
     private static final String KEY_HALO_REVERSED = "halo_reversed";
+    private static final String KEY_HALO_PAUSE = "halo_pause";
     private static final String KEY_QUICK_PULL_DOWN = "quick_pulldown";
     private static final String KEY_AM_PM_STYLE = "am_pm_style";
     private static final String KEY_SHOW_CLOCK = "show_clock";
@@ -78,6 +80,7 @@ public class Toolbar extends SettingsPreferenceFragment
     private ListPreference mHaloState;
     private CheckBoxPreference mHaloHide;
     private CheckBoxPreference mHaloReversed;
+    private CheckBoxPreference mHaloPause;
     private CheckBoxPreference mQuickPullDown;
     private CheckBoxPreference mShowClock;
     private CheckBoxPreference mCircleBattery;
@@ -117,6 +120,11 @@ public class Toolbar extends SettingsPreferenceFragment
         mHaloReversed = (CheckBoxPreference) prefSet.findPreference(KEY_HALO_REVERSED);
         mHaloReversed.setChecked(Settings.System.getInt(mContext.getContentResolver(),
                 Settings.System.HALO_REVERSED, 1) == 1);
+
+        int isLowRAM = (ActivityManager.isLargeRAM()) ? 0 : 1;
+        mHaloPause = (CheckBoxPreference) prefSet.findPreference(KEY_HALO_PAUSE);
+        mHaloPause.setChecked(Settings.System.getInt(mContext.getContentResolver(),
+                Settings.System.HALO_PAUSE, isLowRAM) == 1);
 
         mQuickPullDown = (CheckBoxPreference) prefSet.findPreference(KEY_QUICK_PULL_DOWN);
         mQuickPullDown.setChecked(Settings.System.getInt(mContext.getContentResolver(),
@@ -279,6 +287,10 @@ public class Toolbar extends SettingsPreferenceFragment
             Settings.System.putInt(mContext.getContentResolver(),
                     Settings.System.HALO_REVERSED, mHaloReversed.isChecked()
                     ? 1 : 0);	
+        } else if (preference == mHaloPause) {
+            Settings.System.putInt(mContext.getContentResolver(),
+                    Settings.System.HALO_PAUSE, mHaloPause.isChecked()
+                    ? 1 : 0);
         } else if (preference == mStatusBarNotifCount) {	
             Settings.System.putInt(mContext.getContentResolver(),
                     Settings.System.STATUS_BAR_NOTIF_COUNT,	mStatusBarNotifCount.isChecked()


### PR DESCRIPTION
DO NOT MERGE YET. Please try this out first.
I've been porting this over from my CM10.1 based Halo build.

This adds an option to pause the active app when using HALO.
I've enabled the option by default for devices with low memory. (Do you want that?)
I'm currently using the ActivityManager.isLargeRAM() function which will return true if the device got at least 640MB RAM available to the kernel.

I can customize / enable / disable the default behaviour if you'd like.
But I think it makes sense not to use two foreground activities on older devices which don't have enough RAM (at least by default, users can still change the option if they want).

(Let's use the 1/2 commit for discussions).

Cheers,
tonyp
