### PR TITLE
CM Privacy Guard (2/2)

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -63,6 +63,7 @@
     <uses-permission android:name="android.permission.READ_PROFILE" />
     <uses-permission android:name="android.permission.CONFIGURE_WIFI_DISPLAY" />
     <uses-permission android:name="android.permission.SET_TIME" />
+    <uses-permission android:name="android.permission.CHANGE_PRIVACY_GUARD_STATE" />
 
     <permission
         android:name="android.permission.REQUEST_SUPERUSER"

--- a/res/layout/installed_app_details.xml
+++ b/res/layout/installed_app_details.xml
@@ -69,6 +69,14 @@
                 android:layout_gravity="start"
                 android:layout_marginTop="4dip" />
 
+            <!-- Enable Privacy Guard for an application -->
+            <CheckBox android:id="@+id/privacy_guard_switch"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="start"
+                android:layout_marginTop="4dip"
+                android:text="@string/privacy_guard_switch_label" />
+
         </LinearLayout>
 
         <TextView

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -2565,7 +2565,8 @@
         <li>Disabled apps</li>\n
         <li>Disabled app notifications</li>\n
         <li>Default applications for actions</li>\n
-        <li>Background data restrictions for apps</li>\n\n
+        <li>Background data restrictions for apps</li>\n
+        <li>Privacy guard</li>\n\n
         You will not lose any app data.</string>
     <!-- [CHAR LIMIT=25] Manage applications screen, menu item.  Confirmation button of dialog to confirm resetting user's app preferences. -->
     <string name="reset_app_preferences_button">Reset apps</string>
@@ -2710,7 +2711,6 @@
     <string name="app_disable_notifications_dlg_text">
         If you turn off notifications for this app, you may miss important alerts and updates.
     </string>
-
     <!-- [CHAR LIMIT=25] Services settings screen, setting option name for the user to go to the screen to view app storage use -->
     <string name="storageuse_settings_title">Storage use</string>
     <!-- Services settings screen, setting option summary for the user to go to the screen to app storage use -->
@@ -4823,4 +4823,11 @@
     <string name="auto_brightness_sensitivity_high">High</string>
     <string name="auto_brightness_sensitivity_veryhigh">Very high</string>
 
+    <!-- Privacy Guard -->
+    <string name="app_security_title">App security</string>
+    <string name="privacy_guard_switch_label">Enable Privacy Guard</string>
+    <string name="privacy_guard_dlg_title">Enable Privacy Guard?</string>
+    <string name="privacy_guard_dlg_text">When Privacy Guard is enabled, the app will not be able to access personal data such as contacts, messages, or call logs.</string>
+    <string name="privacy_guard_default_title">Privacy Guard</string>
+    <string name="privacy_guard_default_summary">Enable Privacy Guard by default for newly-installed apps</string>
 </resources>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -4584,6 +4584,7 @@
     <string name="title_tile_battery">Battery stats</string>
     <string name="title_tile_bluetooth">Bluetooth</string>
     <string name="title_tile_brightness">Brightness</string>
+    <string name="title_tile_camera">Camera</string>
     <string name="title_tile_sleep">Go to sleep</string>
     <string name="title_tile_gps">GPS</string>
     <string name="title_tile_torch">Torch</string>

--- a/res/xml/security_settings_app_cyanogenmod.xml
+++ b/res/xml/security_settings_app_cyanogenmod.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (C) 2012 The CyanogenMod Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+
+<PreferenceScreen
+    xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <PreferenceCategory
+        android:key="app_security"
+        android:title="@string/app_security_title">
+
+        <CheckBoxPreference
+            android:key="privacy_guard_default"
+            android:title="@string/privacy_guard_default_title"
+            android:summary="@string/privacy_guard_default_summary"
+            android:persistent="false" />
+
+    </PreferenceCategory>
+
+</PreferenceScreen>

--- a/src/com/android/settings/SecuritySettings.java
+++ b/src/com/android/settings/SecuritySettings.java
@@ -38,6 +38,7 @@ import android.preference.Preference.OnPreferenceChangeListener;
 import android.preference.PreferenceGroup;
 import android.preference.PreferenceScreen;
 import android.provider.Settings;
+import android.provider.Settings.SettingNotFoundException;
 import android.security.KeyStore;
 import android.telephony.TelephonyManager;
 import android.util.Log;
@@ -80,6 +81,9 @@ public class SecuritySettings extends SettingsPreferenceFragment
     private static final String KEY_CREDENTIALS_MANAGER = "credentials_management";
     private static final String PACKAGE_MIME_TYPE = "application/vnd.android.package-archive";
 
+    private static final String KEY_PRIVACY_GUARD_DEFAULT = "privacy_guard_default";
+    private static final String KEY_APP_SECURITY_CATEGORY = "app_security";
+
     DevicePolicyManager mDPM;
 
     private ChooseLockSettingsHelper mChooseLockSettingsHelper;
@@ -99,6 +103,8 @@ public class SecuritySettings extends SettingsPreferenceFragment
     private CheckBoxPreference mPowerButtonInstantlyLocks;
 
     private boolean mIsPrimary;
+
+    private CheckBoxPreference mPrivacyGuardDefault;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -256,6 +262,16 @@ public class SecuritySettings extends SettingsPreferenceFragment
                 deviceAdminCategory.removePreference(mToggleVerifyApps);
             } else {
                 mToggleVerifyApps.setEnabled(false);
+	    }
+
+            // App security settings
+            addPreferencesFromResource(R.xml.security_settings_app_cyanogenmod);
+            mPrivacyGuardDefault = (CheckBoxPreference) findPreference(KEY_PRIVACY_GUARD_DEFAULT);
+            try {
+                mPrivacyGuardDefault.setChecked(Settings.Secure.getInt(getContentResolver(),
+                        Settings.Secure.PRIVACY_GUARD_DEFAULT) == 1);
+            } catch (SettingNotFoundException e) {
+                mPrivacyGuardDefault.setChecked(false);
             }
         }
 
@@ -471,6 +487,9 @@ public class SecuritySettings extends SettingsPreferenceFragment
         } else if (KEY_TOGGLE_VERIFY_APPLICATIONS.equals(key)) {
             Settings.Global.putInt(getContentResolver(), Settings.Global.PACKAGE_VERIFIER_ENABLE,
                     mToggleVerifyApps.isChecked() ? 1 : 0);
+        } else if (KEY_PRIVACY_GUARD_DEFAULT.equals(key)) {
+            Settings.Secure.putInt(getContentResolver(), Settings.Secure.PRIVACY_GUARD_DEFAULT,
+                    mPrivacyGuardDefault.isChecked() ? 1 : 0);
         } else {
             // If we didn't handle it, let preferences handle it.
             return super.onPreferenceTreeClick(preferenceScreen, preference);

--- a/src/com/android/settings/applications/InstalledAppDetails.java
+++ b/src/com/android/settings/applications/InstalledAppDetails.java
@@ -142,6 +142,7 @@ public class InstalledAppDetails extends Fragment
     private Button mClearDataButton;
     private Button mMoveAppButton;
     private CompoundButton mNotificationSwitch, mHaloState;
+    private CompoundButton mPrivacyGuardSwitch;
 
     private PackageMoveObserver mPackageMoveObserver;
 
@@ -181,6 +182,7 @@ public class InstalledAppDetails extends Fragment
     private static final int DLG_DISABLE = DLG_BASE + 7;
     private static final int DLG_DISABLE_NOTIFICATIONS = DLG_BASE + 8;
     private static final int DLG_SPECIAL_DISABLE = DLG_BASE + 9;
+    private static final int DLG_PRIVACY_GUARD = DLG_BASE + 10;
 
     // Menu identifiers
     public static final int UNINSTALL_ALL_USERS_MENU = 1;
@@ -402,6 +404,13 @@ public class InstalledAppDetails extends Fragment
         }
     }
 
+    private void initPrivacyGuardButton() {
+        // TODO: We probably want to disable this optional for the built-in apps
+        boolean enabled = mPm.getPrivacyGuardSetting(mAppEntry.info.packageName);
+        mPrivacyGuardSwitch.setChecked(enabled);
+        mPrivacyGuardSwitch.setOnCheckedChangeListener(this);
+    }
+
     /** Called when the activity is first created. */
     @Override
     public void onCreate(Bundle icicle) {
@@ -487,6 +496,8 @@ public class InstalledAppDetails extends Fragment
         mNotificationSwitch = (CompoundButton) view.findViewById(R.id.notification_switch);
         mHaloState = (CompoundButton) view.findViewById(R.id.halo_state);
         mHaloState.setText((mHaloPolicyIsBlack ? R.string.app_halo_label_black : R.string.app_halo_label_white));
+
+        mPrivacyGuardSwitch = (CompoundButton) view.findViewById(R.id.privacy_guard_switch);
 
         return view;
     }
@@ -850,6 +861,12 @@ public class InstalledAppDetails extends Fragment
             }
         }
 
+
+        // only setup the privacy guard setting if we didn't get uninstalled
+        if (!mMoveInProgress) {
+            initPrivacyGuardButton();
+        }
+
         return true;
     }
 
@@ -1193,6 +1210,25 @@ public class InstalledAppDetails extends Fragment
                     })
                     .setNegativeButton(R.string.dlg_cancel, null)
                     .create();
+                case DLG_PRIVACY_GUARD:
+                    return new AlertDialog.Builder(getActivity())
+                    .setTitle(getActivity().getText(R.string.privacy_guard_dlg_title))
+                    .setIconAttribute(android.R.attr.alertDialogIcon)
+                    .setMessage(getActivity().getText(R.string.privacy_guard_dlg_text))
+                    .setPositiveButton(R.string.dlg_ok,
+                        new DialogInterface.OnClickListener() {
+                        public void onClick(DialogInterface dialog, int which) {
+                            getOwner().setPrivacyGuard(true);
+                        }
+                    })
+                    .setNegativeButton(R.string.dlg_cancel,
+                        new DialogInterface.OnClickListener() {
+                        public void onClick(DialogInterface dialog, int which) {
+                            // Re-enable the checkbox
+                            getOwner().mPrivacyGuardSwitch.setChecked(false);
+                        }
+                    })
+                    .create();
             }
             throw new IllegalArgumentException("unknown id " + id);
         }
@@ -1285,6 +1321,11 @@ public class InstalledAppDetails extends Fragment
         } catch (android.os.RemoteException ex) {
             mHaloState.setChecked(!state); // revert
         }
+    }
+
+    private void setPrivacyGuard(boolean enabled) {
+        String packageName = mAppEntry.info.packageName;
+        mPm.setPrivacyGuardSetting(packageName, enabled);
     }
 
     private int getPremiumSmsPermission(String packageName) {
@@ -1386,6 +1427,12 @@ public class InstalledAppDetails extends Fragment
             }
         } else if (buttonView == mHaloState) {
             setHaloState(isChecked);
+        } else if (buttonView == mPrivacyGuardSwitch) {
+            if (isChecked) {
+                showDialogInner(DLG_PRIVACY_GUARD, 0);
+            } else {
+                setPrivacyGuard(false);
+            }
         }
     }
 }

--- a/src/com/android/settings/cyanogenmod/QuickSettings.java
+++ b/src/com/android/settings/cyanogenmod/QuickSettings.java
@@ -17,6 +17,7 @@
 package com.android.settings.cyanogenmod;
 
 import static com.android.internal.util.cm.QSConstants.TILE_BLUETOOTH;
+import static com.android.internal.util.cm.QSConstants.TILE_CAMERA;
 import static com.android.internal.util.cm.QSConstants.TILE_MOBILEDATA;
 import static com.android.internal.util.cm.QSConstants.TILE_NETWORKMODE;
 import static com.android.internal.util.cm.QSConstants.TILE_NFC;
@@ -44,6 +45,7 @@ import android.text.TextUtils;
 import android.util.Log;
 
 import com.android.internal.telephony.Phone;
+import com.android.internal.util.cm.QSUtils;
 import com.android.settings.R;
 import com.android.settings.SettingsPreferenceFragment;
 import com.android.settings.Utils;
@@ -139,7 +141,7 @@ public class QuickSettings extends SettingsPreferenceFragment implements OnPrefe
         }
         mDynamicUsbTether = (CheckBoxPreference) prefSet.findPreference(DYNAMIC_USBTETHER);
         if (mDynamicUsbTether != null) {
-            if (deviceSupportsUsbTether(getActivity())) {
+            if (QSUtils.deviceSupportsUsbTether(getActivity())) {
                 mDynamicUsbTether.setChecked(Settings.System.getInt(resolver, Settings.System.QS_DYNAMIC_USBTETHER, 1) == 1);
             } else {
                 mDynamicTiles.removePreference(mDynamicUsbTether);
@@ -148,7 +150,7 @@ public class QuickSettings extends SettingsPreferenceFragment implements OnPrefe
         }
         mDynamicWifi = (CheckBoxPreference) prefSet.findPreference(DYNAMIC_WIFI);
         if (mDynamicWifi != null) {
-            if (deviceSupportsWifiDisplay(getActivity())) {
+            if (QSUtils.deviceSupportsWifiDisplay(getActivity())) {
                 mDynamicWifi.setChecked(Settings.System.getInt(resolver, Settings.System.QS_DYNAMIC_WIFI, 1) == 1);
             } else {
                 mDynamicTiles.removePreference(mDynamicWifi);
@@ -157,7 +159,7 @@ public class QuickSettings extends SettingsPreferenceFragment implements OnPrefe
         }
 
         // Don't show mobile data options if not supported
-        if (!deviceSupportsMobileData(getActivity())) {
+        if (!QSUtils.deviceSupportsMobileData(getActivity())) {
             QuickSettingsUtil.TILES.remove(TILE_MOBILEDATA);
             QuickSettingsUtil.TILES.remove(TILE_WIFIAP);
             QuickSettingsUtil.TILES.remove(TILE_NETWORKMODE);
@@ -190,13 +192,18 @@ public class QuickSettings extends SettingsPreferenceFragment implements OnPrefe
         }
 
         // Don't show the bluetooth options if not supported
-        if (!deviceSupportsBluetooth()) {
+        if (!QSUtils.deviceSupportsBluetooth()) {
             QuickSettingsUtil.TILES.remove(TILE_BLUETOOTH);
         }
 
         // Dont show the NFC tile if not supported
         if (!deviceSupportsNfc(getActivity())) {
             QuickSettingsUtil.TILES.remove(TILE_NFC);
+        }
+
+        // Don't show the Camera tile if the device has no cameras
+        if (!QSUtils.deviceSupportsCamera()) {
+            QuickSettingsUtil.TILES.remove(TILE_CAMERA);
         }
     }
 

--- a/src/com/android/settings/cyanogenmod/QuickSettingsUtil.java
+++ b/src/com/android/settings/cyanogenmod/QuickSettingsUtil.java
@@ -22,6 +22,7 @@ import static com.android.internal.util.cm.QSConstants.TILE_AUTOROTATE;
 import static com.android.internal.util.cm.QSConstants.TILE_BATTERY;
 import static com.android.internal.util.cm.QSConstants.TILE_BLUETOOTH;
 import static com.android.internal.util.cm.QSConstants.TILE_BRIGHTNESS;
+import static com.android.internal.util.cm.QSConstants.TILE_CAMERA;
 import static com.android.internal.util.cm.QSConstants.TILE_DELIMITER;
 import static com.android.internal.util.cm.QSConstants.TILE_GPS;
 import static com.android.internal.util.cm.QSConstants.TILE_LOCKSCREEN;
@@ -73,6 +74,9 @@ public class QuickSettingsUtil {
         TILES.put(TILE_BRIGHTNESS, new QuickSettingsUtil.TileInfo(
                 TILE_BRIGHTNESS, R.string.title_tile_brightness,
                 "com.android.systemui:drawable/ic_qs_brightness_auto_off"));
+        TILES.put(TILE_CAMERA, new QuickSettingsUtil.TileInfo(
+                 TILE_CAMERA, R.string.title_tile_camera,
+                "com.android.systemui:drawable/ic_qs_camera"));
         TILES.put(TILE_SLEEP, new QuickSettingsUtil.TileInfo(
                 TILE_SLEEP, R.string.title_tile_sleep,
                 "com.android.systemui:drawable/ic_qs_sleep"));


### PR DESCRIPTION
Adds CyanogenMod's privacy guard feature to AOSPA

settings: Privacy Guard support
- Add toggle to InstalledAppDetails to enable/disable privacy guard flag on
  a per-application basis.
- Add toggle to enable privacy guard by default for applications.

Change-Id: If03aa5319c520b6c4a78887f0f46ef1443ddaa83

Conflicts:
    res/layout/installed_app_details.xml
    res/values/cm_strings.xml
    res/xml/security_settings_app_cyanogenmod.xml
    src/com/android/settings/SecuritySettings.java
    src/com/android/settings/applications/InstalledAppDetails.java

Remove sms security, we don't want it.

Change-Id: I44e38698986ea6bed960ea3407e9132b1d922728

privacy guard: Fix crash when uninstalling an app
- Don't try to update the privacy guard flag while refreshing after an
  uninstall since the PM will throw an exception at us.

Change-Id: Idadb99fefc2861e871f6206b08c844dda742fa68

Add missing string

Change-Id: I499dfaa64fa480293aef1d232160850d7c9112a6

Syntax derp

Change-Id: I74e5b1d8796193d295798b12736b469edc1eb326
