### PR TITLE
Hardware menu fix

### DIFF
--- a/src/com/android/settings/paranoid/Toolbar.java
+++ b/src/com/android/settings/paranoid/Toolbar.java
@@ -248,9 +248,9 @@ public class Toolbar extends SettingsPreferenceFragment
         }
 
         // Only show the hardware keys config on a device that does not have a navbar
-        final int deviceKeys = getResources().getInteger(
-                com.android.internal.R.integer.config_deviceHardwareKeys);
-        if(deviceKeys==15) {
+        final boolean hasNavBar = getResources().getBoolean(
+                com.android.internal.R.bool.config_showNavigationBar);
+        if(hasNavBar) {
              PreferenceScreen HARDWARE =(PreferenceScreen) prefSet.findPreference(KEY_HARDWARE_KEYS);
              prefSet.removePreference(HARDWARE);
         }


### PR DESCRIPTION
This menu never showed up on my device.
Change so it depends on the value of "config_showNavigationBar" which is usually only set for devices without hardware keys.

Change-Id: Icd76990119f57b1f17b639c2de2a094b9c7d8065
