### PR TITLE
Quick Settings: Option to use floating window (1/2)

### DIFF
--- a/res/values/pa_strings.xml
+++ b/res/values/pa_strings.xml
@@ -246,6 +246,8 @@
     <string name="quick_pulldown_right">Right</string>
     <string name="title_collapse_panel">Auto close panel</string>
     <string name="summary_collapse_panel">Close the Quick Settings panel upon toggle</string>
+    <string name="title_floating_window">Floating window</string>
+    <string name="summary_floating_window">Open Quick Settings tiles in floating window</string>
 
     <!-- Reset tiles -->
     <string name="tiles_add_title">Add</string>

--- a/res/xml/quick_settings_panel_settings.xml
+++ b/res/xml/quick_settings_panel_settings.xml
@@ -26,6 +26,11 @@
             android:key="collapse_panel"
             android:title="@string/title_collapse_panel"
             android:summary="@string/summary_collapse_panel" />
+        
+        <CheckBoxPreference
+            android:key="floating_window"
+            android:title="@string/title_floating_window"
+            android:summary="@string/summary_floating_window" />
 
     </PreferenceCategory>
 

--- a/src/com/android/settings/cyanogenmod/QuickSettings.java
+++ b/src/com/android/settings/cyanogenmod/QuickSettings.java
@@ -71,6 +71,7 @@ public class QuickSettings extends SettingsPreferenceFragment implements OnPrefe
     private static final String GENERAL_SETTINGS = "pref_general_settings";
     private static final String STATIC_TILES = "static_tiles";
     private static final String DYNAMIC_TILES = "pref_dynamic_tiles";
+    private static final String FLOATING_WINDOW ="floating_window";
 
     MultiSelectListPreference mRingMode;
     ListPreference mNetworkMode;
@@ -81,6 +82,7 @@ public class QuickSettings extends SettingsPreferenceFragment implements OnPrefe
     CheckBoxPreference mDynamicIme;
     CheckBoxPreference mDynamicUsbTether;
     CheckBoxPreference mCollapsePanel;
+    CheckBoxPreference mFloatingWindow;
     PreferenceCategory mGeneralSettings;
     PreferenceCategory mStaticTiles;
     PreferenceCategory mDynamicTiles;
@@ -104,6 +106,9 @@ public class QuickSettings extends SettingsPreferenceFragment implements OnPrefe
 
         mCollapsePanel = (CheckBoxPreference) prefSet.findPreference(COLLAPSE_PANEL);
         mCollapsePanel.setChecked(Settings.System.getInt(resolver, Settings.System.QS_COLLAPSE_PANEL, 0) == 1);
+        
+        mFloatingWindow = (CheckBoxPreference) prefSet.findPreference(FLOATING_WINDOW);
+        mFloatingWindow.setChecked(Settings.System.getInt(resolver, Settings.System.QS_FLOATING_WINDOW, 0) == 1);
 
         // Add the sound mode
         mRingMode = (MultiSelectListPreference) prefSet.findPreference(EXP_RING_MODE);
@@ -226,6 +231,10 @@ public class QuickSettings extends SettingsPreferenceFragment implements OnPrefe
             Settings.System.putInt(resolver, Settings.System.QS_COLLAPSE_PANEL,
                     mCollapsePanel.isChecked() ? 1 : 0);
             return true;
+        } else if (preference == mFloatingWindow) {
+            Settings.System.putInt(resolver, Settings.System.QS_FLOATING_WINDOW,
+                    mFloatingWindow.isChecked() ? 1 : 0);
+            return true;            
         }
         return super.onPreferenceTreeClick(preferenceScreen, preference);
     }


### PR DESCRIPTION
Allows the option of launching preferences from the quicksettings menu in a
floating window

Depends on fw/base request.

Change-Id: I267cae3cddaf8be697e5c60e21f7ba2616344a19
Signed-off-by: Evan Anderson evan1124@gmail.com
