### PR TITLE
Another way to detect if device has hardware keys

### DIFF
--- a/src/com/android/settings/paranoid/Toolbar.java
+++ b/src/com/android/settings/paranoid/Toolbar.java
@@ -260,9 +260,9 @@ public class Toolbar extends SettingsPreferenceFragment
         }
 
         // Only show the hardware keys config on a device that does not have a navbar
-        final int deviceKeys = getResources().getInteger(
-                com.android.internal.R.integer.config_deviceHardwareKeys);
-        if (deviceKeys==15) {
+        final boolean hasNavBar = getResources().getBoolean(
+                com.android.internal.R.bool.config_showNavigationBar);
+        if(hasNavBar) {
              PreferenceScreen HARDWARE =(PreferenceScreen) prefSet.findPreference(KEY_HARDWARE_KEYS);
              prefSet.removePreference(HARDWARE);
         }


### PR DESCRIPTION
For devices which have all four keys, the value of deviceKeys is set to 15 so this menu is hidden. Change it so it depends on config_showNavigationBar which is set to false by default but true for devices without hardware keys.
