### PR TITLE
Add option for switching between UMS and MTP/PTP mode. (2/2)

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -4570,4 +4570,8 @@
 
     <!-- Delete apn confirmation dialog message -->
     <string name="confirm_delete_apn">The APN will be deleted.</string>
+
+    <!-- USB Mass Storage -->
+    <string name="usb_mass_storage_title">Mass storage</string>
+    <string name="usb_mass_storage_summary">Enable USB mass storage</string>
 </resources>

--- a/res/xml/usb_settings.xml
+++ b/res/xml/usb_settings.xml
@@ -32,4 +32,10 @@
         android:summary="@string/usb_ptp_summary"
         />
 
+    <CheckBoxPreference
+        android:key="usb_mass_storage"
+        android:title="@string/usb_mass_storage_title"
+        android:summary="@string/usb_mass_storage_summary"
+        />
+
 </PreferenceScreen>

--- a/src/com/android/settings/deviceinfo/Memory.java
+++ b/src/com/android/settings/deviceinfo/Memory.java
@@ -175,10 +175,7 @@ public class Memory extends SettingsPreferenceFragment {
     @Override
     public void onPrepareOptionsMenu(Menu menu) {
         final MenuItem usb = menu.findItem(R.id.storage_usb);
-        UserManager um = (UserManager)getActivity().getSystemService(Context.USER_SERVICE);
-        boolean usbItemVisible = !isMassStorageEnabled()
-                && !um.hasUserRestriction(UserManager.DISALLOW_USB_FILE_TRANSFER);
-        usb.setVisible(usbItemVisible);
+        usb.setVisible(true);
     }
 
     @Override

--- a/src/com/android/settings/deviceinfo/UsbSettings.java
+++ b/src/com/android/settings/deviceinfo/UsbSettings.java
@@ -23,6 +23,8 @@ import android.content.IntentFilter;
 import android.hardware.usb.UsbManager;
 import android.os.Bundle;
 import android.os.UserManager;
+import android.os.storage.StorageManager;
+import android.os.storage.StorageVolume;
 import android.preference.CheckBoxPreference;
 import android.preference.Preference;
 import android.preference.PreferenceScreen;
@@ -41,10 +43,14 @@ public class UsbSettings extends SettingsPreferenceFragment {
 
     private static final String KEY_MTP = "usb_mtp";
     private static final String KEY_PTP = "usb_ptp";
+    private static final String KEY_MASS_STORAGE = "usb_mass_storage";
 
     private UsbManager mUsbManager;
+    private StorageManager storageManager;
+    private StorageVolume[] storageVolumes;
     private CheckBoxPreference mMtp;
     private CheckBoxPreference mPtp;
+    private CheckBoxPreference mUms;
     private boolean mUsbAccessoryMode;
 
     private final BroadcastReceiver mStateReceiver = new BroadcastReceiver() {
@@ -68,6 +74,10 @@ public class UsbSettings extends SettingsPreferenceFragment {
 
         mMtp = (CheckBoxPreference)root.findPreference(KEY_MTP);
         mPtp = (CheckBoxPreference)root.findPreference(KEY_PTP);
+        mUms = (CheckBoxPreference)root.findPreference(KEY_MASS_STORAGE);
+        if (!storageVolumes[0].allowMassStorage()) {
+            root.removePreference(mUms);
+        }
 
         UserManager um = (UserManager) getActivity().getSystemService(Context.USER_SERVICE);
         if (um.hasUserRestriction(UserManager.DISALLOW_USB_FILE_TRANSFER)) {
@@ -82,6 +92,8 @@ public class UsbSettings extends SettingsPreferenceFragment {
     public void onCreate(Bundle icicle) {
         super.onCreate(icicle);
         mUsbManager = (UsbManager)getSystemService(Context.USB_SERVICE);
+        storageManager = (StorageManager) getSystemService(Context.STORAGE_SERVICE);
+        storageVolumes = storageManager.getVolumeList();
     }
 
     @Override
@@ -107,12 +119,19 @@ public class UsbSettings extends SettingsPreferenceFragment {
         if (UsbManager.USB_FUNCTION_MTP.equals(function)) {
             mMtp.setChecked(true);
             mPtp.setChecked(false);
+            mUms.setChecked(false);
         } else if (UsbManager.USB_FUNCTION_PTP.equals(function)) {
             mMtp.setChecked(false);
+            mUms.setChecked(false);
             mPtp.setChecked(true);
+        } else if (UsbManager.USB_FUNCTION_MASS_STORAGE.equals(function)) {
+            mMtp.setChecked(false);
+            mPtp.setChecked(false);
+            mUms.setChecked(true);
         } else  {
             mMtp.setChecked(false);
             mPtp.setChecked(false);
+            mUms.setChecked(false);
         }
         UserManager um = (UserManager) getActivity().getSystemService(Context.USER_SERVICE);
         if (um.hasUserRestriction(UserManager.DISALLOW_USB_FILE_TRANSFER)) {
@@ -148,9 +167,14 @@ public class UsbSettings extends SettingsPreferenceFragment {
 
         String function = "none";
         if (preference == mMtp && mMtp.isChecked()) {
+            Settings.Secure.putInt(getContentResolver(), Settings.Secure.USB_MASS_STORAGE_ENABLED, 0 );
             function = UsbManager.USB_FUNCTION_MTP;
         } else if (preference == mPtp && mPtp.isChecked()) {
+            Settings.Secure.putInt(getContentResolver(), Settings.Secure.USB_MASS_STORAGE_ENABLED, 0 );
             function = UsbManager.USB_FUNCTION_PTP;
+        } else if (preference == mUms && mUms.isChecked()) {
+            Settings.Secure.putInt(getContentResolver(), Settings.Secure.USB_MASS_STORAGE_ENABLED, 1 );
+            function = UsbManager.USB_FUNCTION_MASS_STORAGE;
         }
 
         mUsbManager.setCurrentFunction(function, true);

--- a/src/com/android/settings/deviceinfo/UsbSettings.java
+++ b/src/com/android/settings/deviceinfo/UsbSettings.java
@@ -167,13 +167,10 @@ public class UsbSettings extends SettingsPreferenceFragment {
 
         String function = "none";
         if (preference == mMtp && mMtp.isChecked()) {
-            Settings.Secure.putInt(getContentResolver(), Settings.Secure.USB_MASS_STORAGE_ENABLED, 0 );
             function = UsbManager.USB_FUNCTION_MTP;
         } else if (preference == mPtp && mPtp.isChecked()) {
-            Settings.Secure.putInt(getContentResolver(), Settings.Secure.USB_MASS_STORAGE_ENABLED, 0 );
             function = UsbManager.USB_FUNCTION_PTP;
         } else if (preference == mUms && mUms.isChecked()) {
-            Settings.Secure.putInt(getContentResolver(), Settings.Secure.USB_MASS_STORAGE_ENABLED, 1 );
             function = UsbManager.USB_FUNCTION_MASS_STORAGE;
         }
 


### PR DESCRIPTION
Change-Id: I6cf50a41a9a82e40e702f5231ce663636c149613

This adds support for switching between UMS and MTP/PTP.
Settings part (this part) adds option in USB settings (statusbar/notification drawer) for enabling UMS,
and adds setting in Storage menu to enable / disable UMS, this since the USB settings page disappears when enabling UMS.

It's only porting this http://review.cyanogenmod.org/#/c/21115/
